### PR TITLE
Fix git branches triggering directory completion

### DIFF
--- a/fish-completion.el
+++ b/fish-completion.el
@@ -127,7 +127,7 @@ no completion was found with fish."
                      fish-completion-fallback-on-bash-p
                      (require 'bash-completion nil t))
                 (nth 2 (bash-completion-dynamic-complete-nocomint (save-excursion (eshell-bol) (point)) (point)))
-              (if (and comp-list (file-name-directory (car comp-list)))
+              (if (and comp-list (file-exists-p (car comp-list)))
                   (pcomplete-dirs-or-entries)
                 comp-list))))))
 


### PR DESCRIPTION
I'm having a bit of trouble completing git checkouts in this case:

I have completions of branches looking like:

```
upstream/drop-legacy	Branch
upstream/editor-watch	Branch
upstream/is-os	Branch
upstream/keys	Branch
upstream/master	Branch
```

When typing `git checkout ups<TAB>`, I get no completions. 

I took a look at this, and I narrowed it down to:

```
(if (and comp-list (file-name-directory (car comp-list)))
                  (pcomplete-dirs-or-entries)
                comp-list)
```

Since `(file-name-directory "upstream/drop-legacy")` is not nil, it runs the directory completion, which gives nothing. 

This PR tries to improve this by using `file-exists-p` instead of `file-name-directory` to determine if we are looking at a directory/file or not. Let me know if anything seems off.

I don't like how we're only looking at the first element to determine whether to use directory completion, but I think it probably works well for most use cases.
